### PR TITLE
Enhance catalog APIs and add Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,67 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Al-Hamra Brokerage Management API
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+Laravel 10 based backend API for the Al-Hamra Brokerage Management System. The project embraces an API-first architecture to power the web and mobile clients that will cover supplier onboarding, customer transactions, commission distribution, and rank progression.
 
-## About Laravel
+## Getting started
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+### Prerequisites
+- PHP 8.2+
+- Composer 2
+- Node.js 18+
+- MySQL 8 (or any Laravel-supported database)
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+### Installation
+```bash
+cp .env.example .env
+composer install
+php artisan key:generate
+php artisan migrate
+php artisan serve
+```
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+### Running tests
+```bash
+php artisan test
+```
 
-## Learning Laravel
+> **Note:** When working in restricted environments without GitHub access, `composer install` may require GitHub OAuth credentials to download some dependencies from source.
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+## API endpoints
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+All endpoints are prefixed with `/api/v1` and require Sanctum authentication unless stated otherwise.
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+### Authentication
+- `POST /auth/login`
+- `POST /auth/register`
+- `POST /auth/logout` (authenticated)
 
-## Laravel Sponsors
+### Catalog
+- `GET /categories` – List categories with optional `type` and `per_page` filters.
+- `POST /categories` – Create a new category (`name`, `type`).
+- `GET /categories/{id}` – Retrieve category details with product/service counters.
+- `PUT /categories/{id}` – Update the category.
+- `DELETE /categories/{id}` – Delete when no products or services are attached.
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+- `GET /products` – List products filtered by `category_id` or `product_type`.
+- `POST /products` – Create a product (`category_id`, `name`, `product_type`, optional `price`, `attributes`).
+- `GET /products/{id}` – Retrieve product with its category.
+- `PUT /products/{id}` – Update product information.
+- `DELETE /products/{id}` – Remove a product.
 
-### Premium Partners
+- `GET /services` – List services filtered by `category_id`.
+- `POST /services` – Create a service (`category_id`, `name`, optional `price`, `attributes`).
+- `GET /services/{id}` – Retrieve service with its category.
+- `PUT /services/{id}` – Update service information.
+- `DELETE /services/{id}` – Remove a service.
 
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[WebReinvent](https://webreinvent.com/)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel/)**
-- **[Cyber-Duck](https://cyber-duck.co.uk)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Jump24](https://jump24.co.uk)**
-- **[Redberry](https://redberry.international/laravel/)**
-- **[Active Logic](https://activelogic.com)**
-- **[byte5](https://byte5.de)**
-- **[OP.GG](https://op.gg)**
+## Postman collection
 
-## Contributing
+A ready-to-import Postman collection covering the catalog endpoints lives at [`docs/postman/al-hamra-brokerage.postman_collection.json`](docs/postman/al-hamra-brokerage.postman_collection.json). Configure the `base_url` and `access_token` variables after importing to begin testing.
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+## Project structure highlights
+- `app/Http/Controllers` – REST controllers for the catalog domain.
+- `app/Http/Requests` – Form requests that handle validation rules.
+- `app/Http/Resources` – API response transformers ensuring consistent payloads.
+- `database/migrations` – Schema definitions for categories, products, and services.
 
-## Code of Conduct
-
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
-
-## Security Vulnerabilities
-
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
-
-## License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
-# alhamra-api
+Further modules (land management, commissions, ranks, etc.) will build upon this foundation.

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -2,47 +2,105 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ResolvesIncludes;
+use App\Http\Requests\StoreCategoryRequest;
+use App\Http\Requests\UpdateCategoryRequest;
+use App\Http\Resources\CategoryResource;
+use App\Models\Category;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class CategoryController extends Controller
 {
+    use ResolvesIncludes;
+
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request): AnonymousResourceCollection
     {
-        //
+        $includes = $this->resolveIncludes($request, ['products', 'services']);
+
+        $query = Category::query()->withCount(['products', 'services']);
+
+        if (!empty($includes)) {
+            $query->with($includes);
+        }
+
+        if ($request->filled('type')) {
+            $query->where('type', $request->string('type'));
+        }
+
+        $categories = $query->paginate($request->integer('per_page', 15))->appends($request->query());
+
+        return CategoryResource::collection($categories);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreCategoryRequest $request): CategoryResource
     {
-        //
+        $category = Category::create($request->validated());
+
+        $category->loadCount(['products', 'services']);
+
+        $includes = $this->resolveIncludes($request, ['products', 'services']);
+
+        if (!empty($includes)) {
+            $category->load($includes);
+        }
+
+        return new CategoryResource($category);
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(Request $request, Category $category): CategoryResource
     {
-        //
+        $category->loadCount(['products', 'services']);
+
+        $includes = $this->resolveIncludes($request, ['products', 'services']);
+
+        if (!empty($includes)) {
+            $category->load($includes);
+        }
+
+        return new CategoryResource($category);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(UpdateCategoryRequest $request, Category $category): CategoryResource
     {
-        //
+        $category->update($request->validated());
+        $category->loadCount(['products', 'services']);
+
+        $includes = $this->resolveIncludes($request, ['products', 'services']);
+
+        if (!empty($includes)) {
+            $category->load($includes);
+        }
+
+        return new CategoryResource($category);
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Category $category): JsonResponse
     {
-        //
+        if ($category->products()->exists() || $category->services()->exists()) {
+            return response()->json([
+                'message' => 'Category cannot be deleted while products or services are attached.',
+            ], 422);
+        }
+
+        $category->delete();
+
+        return response()->json(null, 204);
     }
 }

--- a/app/Http/Controllers/Concerns/ResolvesIncludes.php
+++ b/app/Http/Controllers/Concerns/ResolvesIncludes.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use Illuminate\Http\Request;
+
+trait ResolvesIncludes
+{
+    /**
+     * Resolve allowed include values from the request.
+     *
+     * @param  array<int, string>  $allowed
+     * @return array<int, string>
+     */
+    protected function resolveIncludes(Request $request, array $allowed): array
+    {
+        return collect(explode(',', (string) $request->query('include')))
+            ->map(static fn (string $include): string => trim($include))
+            ->filter()
+            ->intersect($allowed)
+            ->values()
+            ->all();
+    }
+}

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -2,47 +2,104 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ResolvesIncludes;
+use App\Http\Requests\StoreProductRequest;
+use App\Http\Requests\UpdateProductRequest;
+use App\Http\Resources\ProductResource;
+use App\Models\Product;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ProductController extends Controller
 {
+    use ResolvesIncludes;
+
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request): AnonymousResourceCollection
     {
-        //
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $query = Product::query()->with($includes);
+
+        if ($request->filled('category_id')) {
+            $query->where('category_id', $request->integer('category_id'));
+        }
+
+        if ($request->filled('product_type')) {
+            $query->where('product_type', $request->string('product_type'));
+        }
+
+        $products = $query->paginate($request->integer('per_page', 15))->appends($request->query());
+
+        return ProductResource::collection($products);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreProductRequest $request): ProductResource
     {
-        //
+        $product = Product::create($request->validated());
+
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $product->load($includes);
+
+        return new ProductResource($product);
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(Request $request, Product $product): ProductResource
     {
-        //
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $product->load($includes);
+
+        return new ProductResource($product);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(UpdateProductRequest $request, Product $product): ProductResource
     {
-        //
+        $product->update($request->validated());
+
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $product->load($includes);
+
+        return new ProductResource($product);
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Product $product): JsonResponse
     {
-        //
+        $product->delete();
+
+        return response()->json(null, 204);
     }
 }

--- a/app/Http/Controllers/ServiceController.php
+++ b/app/Http/Controllers/ServiceController.php
@@ -2,47 +2,100 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ResolvesIncludes;
+use App\Http\Requests\StoreServiceRequest;
+use App\Http\Requests\UpdateServiceRequest;
+use App\Http\Resources\ServiceResource;
+use App\Models\Service;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ServiceController extends Controller
 {
+    use ResolvesIncludes;
+
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request): AnonymousResourceCollection
     {
-        //
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $query = Service::query()->with($includes);
+
+        if ($request->filled('category_id')) {
+            $query->where('category_id', $request->integer('category_id'));
+        }
+
+        $services = $query->paginate($request->integer('per_page', 15))->appends($request->query());
+
+        return ServiceResource::collection($services);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreServiceRequest $request): ServiceResource
     {
-        //
+        $service = Service::create($request->validated());
+
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $service->load($includes);
+
+        return new ServiceResource($service);
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(Request $request, Service $service): ServiceResource
     {
-        //
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $service->load($includes);
+
+        return new ServiceResource($service);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(UpdateServiceRequest $request, Service $service): ServiceResource
     {
-        //
+        $service->update($request->validated());
+
+        $includes = $this->resolveIncludes($request, ['category']);
+
+        if (empty($includes)) {
+            $includes = ['category'];
+        }
+
+        $service->load($includes);
+
+        return new ServiceResource($service);
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Service $service): JsonResponse
     {
-        //
+        $service->delete();
+
+        return response()->json(null, 204);
     }
 }

--- a/app/Http/Requests/StoreCategoryRequest.php
+++ b/app/Http/Requests/StoreCategoryRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'type' => ['required', 'in:product,service'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'category_id' => ['required', 'integer', 'exists:categories,id'],
+            'name' => ['required', 'string', 'max:255'],
+            'product_type' => ['required', 'in:small,big,land,share,other'],
+            'price' => ['nullable', 'numeric', 'min:0'],
+            'attributes' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreServiceRequest.php
+++ b/app/Http/Requests/StoreServiceRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreServiceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'category_id' => ['required', 'integer', 'exists:categories,id'],
+            'name' => ['required', 'string', 'max:255'],
+            'price' => ['nullable', 'numeric', 'min:0'],
+            'attributes' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCategoryRequest.php
+++ b/app/Http/Requests/UpdateCategoryRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'type' => ['sometimes', 'required', 'in:product,service'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateProductRequest.php
+++ b/app/Http/Requests/UpdateProductRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'category_id' => ['sometimes', 'required', 'integer', 'exists:categories,id'],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'product_type' => ['sometimes', 'required', 'in:small,big,land,share,other'],
+            'price' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'attributes' => ['sometimes', 'nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateServiceRequest.php
+++ b/app/Http/Requests/UpdateServiceRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateServiceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'category_id' => ['sometimes', 'required', 'integer', 'exists:categories,id'],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'price' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'attributes' => ['sometimes', 'nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Category
+ */
+class CategoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'type' => $this->type,
+            'products_count' => $this->whenCounted('products'),
+            'services_count' => $this->whenCounted('services'),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'products' => ProductResource::collection($this->whenLoaded('products')),
+            'services' => ServiceResource::collection($this->whenLoaded('services')),
+        ];
+    }
+}

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Product
+ */
+class ProductResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'category_id' => $this->category_id,
+            'category' => new CategoryResource($this->whenLoaded('category')),
+            'name' => $this->name,
+            'product_type' => $this->product_type,
+            'price' => $this->price,
+            'attributes' => $this->getAttribute('attributes') ?? [],
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/ServiceResource.php
+++ b/app/Http/Resources/ServiceResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Service
+ */
+class ServiceResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'category_id' => $this->category_id,
+            'category' => new CategoryResource($this->whenLoaded('category')),
+            'name' => $this->name,
+            'price' => $this->price,
+            'attributes' => $this->getAttribute('attributes') ?? [],
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -4,8 +4,35 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Category extends Model
 {
     use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'type',
+    ];
+
+    /**
+     * Products that fall under the category.
+     */
+    public function products(): HasMany
+    {
+        return $this->hasMany(Product::class);
+    }
+
+    /**
+     * Services that fall under the category.
+     */
+    public function services(): HasMany
+    {
+        return $this->hasMany(Service::class);
+    }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -4,8 +4,36 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Product extends Model
 {
     use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'category_id',
+        'name',
+        'product_type',
+        'price',
+        'attributes',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'attributes' => 'array',
+        'price' => 'decimal:2',
+    ];
+
+    /**
+     * The category the product belongs to.
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
 }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -4,8 +4,35 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Service extends Model
 {
     use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'category_id',
+        'name',
+        'price',
+        'attributes',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'attributes' => 'array',
+        'price' => 'decimal:2',
+    ];
+
+    /**
+     * The category the service belongs to.
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
 }

--- a/database/migrations/2025_10_06_112309_create_categories_table.php
+++ b/database/migrations/2025_10_06_112309_create_categories_table.php
@@ -11,9 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('categories', function (Blueprint $t) {
-            $t->id(); $t->string('name'); $t->enum('type',['product','service']); $t->timestamps();
-            });
+        Schema::create('categories', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->enum('type', ['product', 'service']);
+            $table->timestamps();
+        });
     }
 
     /**

--- a/database/migrations/2025_10_06_112310_create_products_table.php
+++ b/database/migrations/2025_10_06_112310_create_products_table.php
@@ -11,14 +11,17 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('products', function (Blueprint $t) {
-        $t->id();
-        $t->foreignId('category_id')->constrained();
-        $t->string('name');
-        $t->enum('product_type', ['small','big','land','share','other']);
-        $t->decimal('price',14,2)->default(0);
-        $t->json('attributes')->nullable(); // কাস্টম অ্যাট্রিবিউট
-        $t->timestamps();
+        Schema::create('products', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('category_id')
+                ->constrained()
+                ->cascadeOnUpdate()
+                ->restrictOnDelete();
+            $table->string('name');
+            $table->enum('product_type', ['small', 'big', 'land', 'share', 'other']);
+            $table->decimal('price', 14, 2)->default(0);
+            $table->json('attributes')->nullable();
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2025_10_06_112310_create_services_table.php
+++ b/database/migrations/2025_10_06_112310_create_services_table.php
@@ -11,13 +11,16 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('services', function (Blueprint $t) {
-        $t->id();
-        $t->foreignId('category_id')->constrained();
-        $t->string('name');
-        $t->decimal('price',14,2)->default(0);
-        $t->json('attributes')->nullable();
-        $t->timestamps();
+        Schema::create('services', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('category_id')
+                ->constrained()
+                ->cascadeOnUpdate()
+                ->restrictOnDelete();
+            $table->string('name');
+            $table->decimal('price', 14, 2)->default(0);
+            $table->json('attributes')->nullable();
+            $table->timestamps();
         });
     }
 

--- a/docs/postman/al-hamra-brokerage.postman_collection.json
+++ b/docs/postman/al-hamra-brokerage.postman_collection.json
@@ -1,0 +1,603 @@
+{
+  "info": {
+    "name": "Al-Hamra Brokerage API v1",
+    "description": "Postman collection for the catalog endpoints of the Al-Hamra Brokerage Management System.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Authentication",
+      "item": [
+        {
+          "name": "Login",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"user@example.com\",\n  \"password\": \"secret\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/v1/auth/login",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Categories",
+      "item": [
+        {
+          "name": "List Categories",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/categories",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "categories"
+              ],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "product",
+                  "disabled": true
+                },
+                {
+                  "key": "per_page",
+                  "value": "15",
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Category",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Real Estate\",\n  \"type\": \"product\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/v1/categories",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "categories"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Show Category",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/categories/{{category_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "categories",
+                "{{category_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Category",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Hospital Services\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/v1/categories/{{category_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "categories",
+                "{{category_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Category",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/categories/{{category_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "categories",
+                "{{category_id}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Products",
+      "item": [
+        {
+          "name": "List Products",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/products",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "products"
+              ],
+              "query": [
+                {
+                  "key": "category_id",
+                  "value": "1",
+                  "disabled": true
+                },
+                {
+                  "key": "product_type",
+                  "value": "land",
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Product",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"category_id\": {{category_id}},\n  \"name\": \"Premium Land Parcel\",\n  \"product_type\": \"land\",\n  \"price\": 5000000,\n  \"attributes\": {\n    \"plot_size\": \"5 katha\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/v1/products",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "products"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Show Product",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/products/{{product_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "products",
+                "{{product_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Product",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Premium Land Parcel - North\",\n  \"price\": 5200000\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/v1/products/{{product_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "products",
+                "{{product_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Product",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/products/{{product_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "products",
+                "{{product_id}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Services",
+      "item": [
+        {
+          "name": "List Services",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/services",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "services"
+              ],
+              "query": [
+                {
+                  "key": "category_id",
+                  "value": "1",
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Service",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"category_id\": {{category_id}},\n  \"name\": \"Premium Hajj Package\",\n  \"price\": 350000,\n  \"attributes\": {\n    \"duration\": \"15 days\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/v1/services",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "services"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Show Service",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/services/{{service_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "services",
+                "{{service_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Service",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"price\": 360000\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/v1/services/{{service_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "services",
+                "{{service_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Service",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/services/{{service_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "services",
+                "{{service_id}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost"
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "category_id",
+      "value": "1",
+      "type": "string"
+    },
+    {
+      "key": "product_id",
+      "value": "1",
+      "type": "string"
+    },
+    {
+      "key": "service_id",
+      "value": "1",
+      "type": "string"
+    }
+  ]
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,15 @@
 <?php
 
-use Illuminate\Http\Request;
+use App\Http\Controllers\AgentController;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\BranchController;
+use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\InstallmentController;
+use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\ReportController;
+use App\Http\Controllers\SalesOrderController;
+use App\Http\Controllers\ServiceController;
 use Illuminate\Support\Facades\Route;
 
 /*


### PR DESCRIPTION
## Summary
- add an include-resolution helper and load optional relationships in the category, product, and service APIs
- return normalized attribute payloads and polish catalog migrations and documentation for the project
- publish a ready-to-import Postman collection covering authentication and catalog endpoints

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68e3ad56ea208333b96eeb077b968ebb