### PR TITLE
Implement sales order context and permissions

### DIFF
--- a/app/Http/Controllers/SalesOrderController.php
+++ b/app/Http/Controllers/SalesOrderController.php
@@ -2,47 +2,332 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Agent;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\SalesOrder;
+use App\Models\Service;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 
 class SalesOrderController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
+    public function index(Request $request)
     {
-        //
+        $this->ensureSalesEntryPermission($request->user());
+
+        $orders = SalesOrder::with([
+            'items.itemable',
+            'agent.user',
+            'branch',
+            'customer',
+            'employee.user',
+            'introducer',
+        ])
+            ->when($request->query('sales_type'), function ($query, $salesType) {
+                if (in_array($salesType, SalesOrder::SALES_TYPES, true)) {
+                    $query->where('sales_type', $salesType);
+                }
+            })
+            ->orderByDesc('id')
+            ->paginate((int) $request->query('per_page', 15));
+
+        return response()->json($orders);
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request)
     {
-        //
+        $user = $request->user();
+        $this->ensureSalesEntryPermission($user);
+
+        $employee = $user?->employee;
+
+        if (! $employee) {
+            throw ValidationException::withMessages([
+                'employee_id' => 'The authenticated user is not linked to an employee profile.',
+            ]);
+        }
+
+        $data = $request->validate([
+            'customer_id' => ['required', 'integer', 'exists:users,id'],
+            'sales_type' => ['required', 'string', Rule::in(SalesOrder::SALES_TYPES)],
+            'branch_id' => ['sometimes', 'integer', 'exists:branches,id'],
+            'agent_id' => ['sometimes', 'integer', 'exists:agents,id'],
+            'rank' => ['sometimes', 'string', Rule::in(Employee::RANKS)],
+            'introducer_id' => ['nullable', 'integer', 'different:customer_id', 'exists:users,id'],
+            'down_payment' => ['required', 'numeric', 'min:0'],
+            'total' => ['required', 'numeric', 'min:0'],
+            'items' => ['sometimes', 'array'],
+            'items.*.item_type' => ['required_with:items', 'string', 'in:product,service'],
+            'items.*.item_id' => ['required_with:items', 'integer'],
+            'items.*.qty' => ['required_with:items', 'integer', 'min:1'],
+            'items.*.unit_price' => ['nullable', 'numeric', 'min:0'],
+        ]);
+
+        $data = $this->resolveEmployeeContext($data, $employee);
+
+        $preparedItems = null;
+        if (! empty($data['items'])) {
+            $preparedItems = $this->prepareOrderItems($data['items']);
+            $data['items'] = $preparedItems['items'];
+            if ($preparedItems['total'] > 0) {
+                $data['total'] = $preparedItems['total'];
+            }
+        }
+
+        if ($data['down_payment'] > $data['total']) {
+            throw ValidationException::withMessages([
+                'down_payment' => 'The down payment may not be greater than the total amount.',
+            ]);
+        }
+
+        $this->ensureAgentBelongsToBranch($data['agent_id'], $data['branch_id']);
+
+        $order = DB::transaction(function () use ($data, $preparedItems) {
+            $payload = Arr::only($data, [
+                'customer_id',
+                'employee_id',
+                'agent_id',
+                'branch_id',
+                'sales_type',
+                'rank',
+                'introducer_id',
+                'down_payment',
+                'total',
+            ]);
+            $payload['status'] = SalesOrder::STATUS_ACTIVE;
+
+            /** @var SalesOrder $order */
+            $order = SalesOrder::create($payload);
+
+            if ($preparedItems) {
+                $order->items()->createMany($preparedItems['items']);
+            }
+
+            return $order;
+        });
+
+        return response()->json([
+            'data' => $order->load([
+                'items.itemable',
+                'agent.user',
+                'branch',
+                'customer',
+                'employee.user',
+                'introducer',
+            ]),
+        ], 201);
     }
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
+    public function show(Request $request, SalesOrder $salesOrder)
     {
-        //
+        $this->ensureSalesEntryPermission($request->user());
+
+        return response()->json([
+            'data' => $salesOrder->load([
+                'items.itemable',
+                'agent.user',
+                'branch',
+                'customer',
+                'employee.user',
+                'introducer',
+            ]),
+        ]);
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
+    public function update(Request $request, SalesOrder $salesOrder)
     {
-        //
+        $this->ensureSalesEntryPermission($request->user());
+
+        $data = $request->validate([
+            'customer_id' => ['sometimes', 'integer', 'exists:users,id'],
+            'sales_type' => ['sometimes', 'string', Rule::in(SalesOrder::SALES_TYPES)],
+            'branch_id' => ['sometimes', 'integer', 'exists:branches,id'],
+            'agent_id' => ['sometimes', 'integer', 'exists:agents,id'],
+            'rank' => ['sometimes', 'string', Rule::in(Employee::RANKS)],
+            'introducer_id' => ['sometimes', 'nullable', 'integer', 'different:customer_id', 'exists:users,id'],
+            'down_payment' => ['sometimes', 'numeric', 'min:0'],
+            'total' => ['sometimes', 'numeric', 'min:0'],
+            'status' => ['sometimes', 'string', Rule::in(SalesOrder::STATUSES)],
+            'items' => ['sometimes', 'array'],
+            'items.*.item_type' => ['required_with:items', 'string', 'in:product,service'],
+            'items.*.item_id' => ['required_with:items', 'integer'],
+            'items.*.qty' => ['required_with:items', 'integer', 'min:1'],
+            'items.*.unit_price' => ['nullable', 'numeric', 'min:0'],
+        ]);
+
+        $itemsProvided = array_key_exists('items', $data);
+        $preparedItems = ['items' => []];
+
+        if ($itemsProvided) {
+            $preparedItems = $this->prepareOrderItems($data['items'] ?? []);
+            $data['total'] = $preparedItems['total'];
+            unset($data['items']);
+        }
+
+        $branchId = $data['branch_id'] ?? $salesOrder->branch_id;
+        $agentId = $data['agent_id'] ?? $salesOrder->agent_id;
+        $this->ensureAgentBelongsToBranch($agentId, $branchId);
+
+        $total = $data['total'] ?? $salesOrder->total;
+        $downPayment = $data['down_payment'] ?? $salesOrder->down_payment;
+
+        if ($downPayment > $total) {
+            throw ValidationException::withMessages([
+                'down_payment' => 'The down payment may not be greater than the total amount.',
+            ]);
+        }
+
+        DB::transaction(function () use ($salesOrder, $data, $itemsProvided, $preparedItems) {
+            $salesOrder->fill($data);
+            $salesOrder->save();
+
+            if ($itemsProvided) {
+                $salesOrder->items()->delete();
+
+                if (! empty($preparedItems['items'])) {
+                    $salesOrder->items()->createMany($preparedItems['items']);
+                }
+            }
+        });
+
+        return response()->json([
+            'data' => $salesOrder->fresh()->load([
+                'items.itemable',
+                'agent.user',
+                'branch',
+                'customer',
+                'employee.user',
+                'introducer',
+            ]),
+        ]);
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
+    public function destroy(Request $request, SalesOrder $salesOrder)
     {
-        //
+        $this->ensureSalesEntryPermission($request->user());
+
+        $salesOrder->delete();
+
+        return response()->noContent();
+    }
+
+    private function ensureSalesEntryPermission(?User $user): void
+    {
+        if (! $user || ! in_array($user->role, [
+            User::ROLE_ADMIN,
+            User::ROLE_BRANCH_ADMIN,
+            User::ROLE_AGENT_ADMIN,
+        ], true)) {
+            abort(403, 'You are not authorised to manage sales entries.');
+        }
+    }
+
+    private function resolveEmployeeContext(array $data, Employee $employee): array
+    {
+        $data['employee_id'] = $employee->id;
+
+        if (! array_key_exists('branch_id', $data) || is_null($data['branch_id'])) {
+            $data['branch_id'] = $employee->branch_id;
+        }
+
+        if (! array_key_exists('agent_id', $data) || is_null($data['agent_id'])) {
+            $data['agent_id'] = $employee->agent_id;
+        }
+
+        if (! array_key_exists('rank', $data) || is_null($data['rank'])) {
+            $data['rank'] = $employee->rank;
+        }
+
+        $messages = [];
+
+        foreach (['branch_id', 'agent_id', 'rank'] as $field) {
+            if (! isset($data[$field])) {
+                $messages[$field] = 'The '.$field.' could not be determined from the employee profile.';
+            }
+        }
+
+        if ($messages) {
+            throw ValidationException::withMessages($messages);
+        }
+
+        $data['branch_id'] = (int) $data['branch_id'];
+        $data['agent_id'] = (int) $data['agent_id'];
+
+        return $data;
+    }
+
+    private function ensureAgentBelongsToBranch(?int $agentId, ?int $branchId): void
+    {
+        if (! $agentId || ! $branchId) {
+            return;
+        }
+
+        $agent = Agent::find($agentId);
+
+        if ($agent && $agent->branch_id && (int) $agent->branch_id !== (int) $branchId) {
+            throw ValidationException::withMessages([
+                'agent_id' => 'The selected agent does not belong to the specified branch.',
+            ]);
+        }
+    }
+
+    private function prepareOrderItems(array $items): array
+    {
+        $resolved = [];
+        $total = 0;
+
+        foreach ($items as $index => $itemData) {
+            $itemable = $this->resolveItemable($itemData['item_type'] ?? '', (int) ($itemData['item_id'] ?? 0), $index);
+            $qty = (int) ($itemData['qty'] ?? 0);
+            $unitPrice = array_key_exists('unit_price', $itemData)
+                ? (float) $itemData['unit_price']
+                : (float) ($itemable->price ?? 0);
+            $lineTotal = round($qty * $unitPrice, 2);
+
+            $resolved[] = [
+                'itemable_type' => get_class($itemable),
+                'itemable_id' => $itemable->id,
+                'qty' => $qty,
+                'unit_price' => $unitPrice,
+                'line_total' => $lineTotal,
+            ];
+
+            $total += $lineTotal;
+        }
+
+        return [
+            'items' => $resolved,
+            'total' => round($total, 2),
+        ];
+    }
+
+    private function resolveItemable(string $type, int $id, int $index)
+    {
+        $map = [
+            'product' => Product::class,
+            'service' => Service::class,
+        ];
+
+        if (! array_key_exists($type, $map)) {
+            throw ValidationException::withMessages([
+                "items.$index.item_type" => 'The selected item type is invalid.',
+            ]);
+        }
+
+        $modelClass = $map[$type];
+        $model = $modelClass::find($id);
+
+        if (! $model) {
+            throw ValidationException::withMessages([
+                "items.$index.item_id" => 'The selected item is invalid.',
+            ]);
+        }
+
+        return $model;
     }
 }

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\LogsActivityChanges;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Employee extends Model
+{
+    use HasFactory;
+    use LogsActivityChanges;
+
+    public const RANK_ME = 'ME';
+    public const RANK_MM = 'MM';
+    public const RANK_DGM = 'DGM';
+    public const RANK_GM = 'GM';
+    public const RANK_PD = 'PD';
+    public const RANK_ED = 'ED';
+    public const RANK_DMD = 'DMD';
+    public const RANK_HD = 'HD';
+
+    public const RANKS = [
+        self::RANK_ME,
+        self::RANK_MM,
+        self::RANK_DGM,
+        self::RANK_GM,
+        self::RANK_PD,
+        self::RANK_ED,
+        self::RANK_DMD,
+        self::RANK_HD,
+    ];
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'branch_id',
+        'agent_id',
+        'rank',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
+    }
+
+    public function agent(): BelongsTo
+    {
+        return $this->belongsTo(Agent::class);
+    }
+}

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -2,10 +2,41 @@
 
 namespace App\Models;
 
+use App\Traits\LogsActivityChanges;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class OrderItem extends Model
 {
     use HasFactory;
+    use LogsActivityChanges;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'sales_order_id',
+        'itemable_id',
+        'itemable_type',
+        'qty',
+        'unit_price',
+        'line_total',
+    ];
+
+    protected $casts = [
+        'unit_price' => 'decimal:2',
+        'line_total' => 'decimal:2',
+    ];
+
+    public function salesOrder(): BelongsTo
+    {
+        return $this->belongsTo(SalesOrder::class);
+    }
+
+    public function itemable(): MorphTo
+    {
+        return $this->morphTo();
+    }
 }

--- a/app/Models/SalesOrder.php
+++ b/app/Models/SalesOrder.php
@@ -13,10 +13,38 @@ class SalesOrder extends Model
     use HasFactory;
     use LogsActivityChanges;
 
+    public const TYPE_LAND = 'land';
+    public const TYPE_ORDER = 'order';
+    public const TYPE_SERVICE = 'service';
+    public const TYPE_SHARE = 'share';
+
+    public const STATUS_DRAFT = 'draft';
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    public const SALES_TYPES = [
+        self::TYPE_LAND,
+        self::TYPE_ORDER,
+        self::TYPE_SERVICE,
+        self::TYPE_SHARE,
+    ];
+
+    public const STATUSES = [
+        self::STATUS_DRAFT,
+        self::STATUS_ACTIVE,
+        self::STATUS_COMPLETED,
+        self::STATUS_CANCELLED,
+    ];
+
     protected $fillable = [
         'customer_id',
+        'employee_id',
         'agent_id',
         'branch_id',
+        'sales_type',
+        'rank',
+        'introducer_id',
         'down_payment',
         'total',
         'status',
@@ -37,6 +65,11 @@ class SalesOrder extends Model
         return $this->belongsTo(Agent::class);
     }
 
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
     public function branch(): BelongsTo
     {
         return $this->belongsTo(Branch::class);
@@ -45,6 +78,11 @@ class SalesOrder extends Model
     public function customer(): BelongsTo
     {
         return $this->belongsTo(User::class, 'customer_id');
+    }
+
+    public function introducer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'introducer_id');
     }
 
     public function installments(): HasMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -13,12 +14,16 @@ class User extends Authenticatable
     use HasApiTokens, HasFactory, Notifiable;
 
     public const ROLE_ADMIN = 'admin';
+    public const ROLE_BRANCH_ADMIN = 'branch_admin';
+    public const ROLE_AGENT_ADMIN = 'agent_admin';
     public const ROLE_EMPLOYEE = 'employee';
     public const ROLE_OWNER = 'owner';
     public const ROLE_DIRECTOR = 'director';
 
     public const ROLES = [
         self::ROLE_ADMIN,
+        self::ROLE_BRANCH_ADMIN,
+        self::ROLE_AGENT_ADMIN,
         self::ROLE_EMPLOYEE,
         self::ROLE_OWNER,
         self::ROLE_DIRECTOR,
@@ -55,4 +60,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function employee(): HasOne
+    {
+        return $this->hasOne(Employee::class);
+    }
 }

--- a/database/migrations/2025_10_07_010000_create_employees_table.php
+++ b/database/migrations/2025_10_07_010000_create_employees_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employees', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->foreignId('branch_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('agent_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('rank')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employees');
+    }
+};

--- a/database/migrations/2025_10_07_010100_add_context_to_sales_orders_table.php
+++ b/database/migrations/2025_10_07_010100_add_context_to_sales_orders_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sales_orders', function (Blueprint $table) {
+            $table->foreignId('employee_id')->nullable()->after('customer_id')->constrained()->nullOnDelete();
+            $table->string('sales_type')->default('order')->after('agent_id');
+            $table->string('rank')->nullable()->after('sales_type');
+            $table->foreignId('introducer_id')->nullable()->after('rank')->constrained('users')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sales_orders', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('employee_id');
+            $table->dropColumn('sales_type');
+            $table->dropColumn('rank');
+            $table->dropConstrainedForeignId('introducer_id');
+        });
+    }
+};

--- a/database/migrations/2025_10_07_010200_create_activity_log_table.php
+++ b/database/migrations/2025_10_07_010200_create_activity_log_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('log_name')->nullable();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('properties')->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->uuid('batch_uuid')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_log');
+    }
+};

--- a/tests/Feature/SalesOrderTest.php
+++ b/tests/Feature/SalesOrderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Agent;
+use App\Models\Branch;
+use App\Models\Category;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\SalesOrder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SalesOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_create_sales_order_with_implicit_context(): void
+    {
+        $branch = Branch::create([
+            'name' => 'Dhaka Branch',
+            'code' => 'DHK',
+            'address' => 'Dhaka',
+        ]);
+
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $agent = Agent::create([
+            'user_id' => $admin->id,
+            'branch_id' => $branch->id,
+            'agent_code' => Str::uuid()->toString(),
+        ]);
+
+        Employee::create([
+            'user_id' => $admin->id,
+            'branch_id' => $branch->id,
+            'agent_id' => $agent->id,
+            'rank' => Employee::RANK_MM,
+        ]);
+
+        $customer = User::factory()->create();
+
+        $category = Category::create([
+            'name' => 'Land',
+            'type' => 'product',
+        ]);
+
+        $product = Product::create([
+            'category_id' => $category->id,
+            'name' => 'Premium Plot',
+            'product_type' => 'land',
+            'price' => 500000,
+            'attributes' => [],
+        ]);
+
+        Sanctum::actingAs($admin);
+
+        $response = $this->postJson('/api/v1/sales-orders', [
+            'customer_id' => $customer->id,
+            'sales_type' => SalesOrder::TYPE_LAND,
+            'down_payment' => 50000,
+            'total' => 500000,
+            'items' => [
+                [
+                    'item_type' => 'product',
+                    'item_id' => $product->id,
+                    'qty' => 1,
+                ],
+            ],
+        ]);
+
+        $response->assertCreated();
+
+        $response->assertJsonPath('data.branch_id', $branch->id);
+        $response->assertJsonPath('data.agent_id', $agent->id);
+        $response->assertJsonPath('data.rank', Employee::RANK_MM);
+        $response->assertJsonPath('data.employee_id', $admin->employee->id);
+        $response->assertJsonPath('data.sales_type', SalesOrder::TYPE_LAND);
+        $response->assertJsonPath('data.items.0.itemable_id', $product->id);
+
+        $this->assertDatabaseHas('sales_orders', [
+            'customer_id' => $customer->id,
+            'branch_id' => $branch->id,
+            'agent_id' => $agent->id,
+            'rank' => Employee::RANK_MM,
+            'sales_type' => SalesOrder::TYPE_LAND,
+        ]);
+    }
+
+    public function test_rank_employee_cannot_create_sales_order(): void
+    {
+        $branch = Branch::create([
+            'name' => 'Chattogram Branch',
+            'code' => 'CTG',
+            'address' => 'Chattogram',
+        ]);
+
+        $rankUser = User::factory()->create([
+            'role' => User::ROLE_EMPLOYEE,
+        ]);
+
+        $agent = Agent::create([
+            'user_id' => $rankUser->id,
+            'branch_id' => $branch->id,
+            'agent_code' => Str::uuid()->toString(),
+        ]);
+
+        Employee::create([
+            'user_id' => $rankUser->id,
+            'branch_id' => $branch->id,
+            'agent_id' => $agent->id,
+            'rank' => Employee::RANK_ME,
+        ]);
+
+        $customer = User::factory()->create();
+
+        Sanctum::actingAs($rankUser);
+
+        $response = $this->postJson('/api/v1/sales-orders', [
+            'customer_id' => $customer->id,
+            'sales_type' => SalesOrder::TYPE_SERVICE,
+            'down_payment' => 1000,
+            'total' => 2000,
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('sales_orders', 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add an employee profile model and migrations to capture branch, agent, and rank context for sales entries
- extend the sales order domain to include sales type, rank, introducer tracking, and enforce branch/agent validation with comprehensive API handling
- register supporting migrations and feature tests covering authorised sales entry creation and rank-user access restrictions

## Testing
- ⚠️ `php artisan test` *(fails: composer install could not complete because GitHub API downloads returned 403 responses)*

------
https://chatgpt.com/codex/tasks/task_b_68e3f42c3c00833395895c3ad0dbef99