### PR TITLE
Add comprehensive demo data seeder

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,10 +8,14 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens;
+    use HasFactory;
+    use Notifiable;
+    use HasRoles;
 
     public const ROLE_ADMIN = 'admin';
     public const ROLE_BRANCH_ADMIN = 'branch_admin';

--- a/database/seeders/CoreDataSeeder.php
+++ b/database/seeders/CoreDataSeeder.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Branch;
+use App\Models\Category;
+use App\Models\CommissionRule;
+use App\Models\LedgerAccount;
+use App\Models\RankRequirement;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
+
+class CoreDataSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->seedBranches();
+        $this->seedCategories();
+        $this->seedRankRequirements();
+        $this->seedLedgerAccounts();
+        $this->seedCommissionRules();
+    }
+
+    private function seedBranches(): void
+    {
+        $branches = [
+            [
+                'code' => 'DHK-HQ',
+                'name' => 'Dhaka Head Office',
+                'address' => 'Level 12, Al-Hamra Tower, Gulshan-2, Dhaka',
+            ],
+            [
+                'code' => 'CTG-CEN',
+                'name' => 'Chattogram Central',
+                'address' => 'Bayazid Bostami Road, Chattogram',
+            ],
+            [
+                'code' => 'SYL-HILL',
+                'name' => 'Sylhet Hill View',
+                'address' => 'Zindabazar, Sylhet',
+            ],
+        ];
+
+        foreach ($branches as $branch) {
+            Branch::updateOrCreate(
+                ['code' => $branch['code']],
+                Arr::only($branch, ['name', 'address'])
+            );
+        }
+    }
+
+    private function seedCategories(): void
+    {
+        $categories = [
+            ['name' => 'Land & Plot', 'type' => 'product'],
+            ['name' => 'Residential Apartment', 'type' => 'product'],
+            ['name' => 'Construction Material', 'type' => 'product'],
+            ['name' => 'Share Investment', 'type' => 'product'],
+            ['name' => 'Hospitality Service', 'type' => 'service'],
+            ['name' => 'Healthcare Service', 'type' => 'service'],
+            ['name' => 'Transport Logistics', 'type' => 'service'],
+            ['name' => 'Hajj & Umrah Package', 'type' => 'service'],
+            ['name' => 'Tourism Package', 'type' => 'service'],
+        ];
+
+        foreach ($categories as $category) {
+            Category::updateOrCreate(
+                ['name' => $category['name'], 'type' => $category['type']],
+                []
+            );
+        }
+    }
+
+    private function seedRankRequirements(): void
+    {
+        $ranks = [
+            [
+                'rank' => 'ME',
+                'sequence' => 1,
+                'personal_sales_target' => 0,
+                'bonus_down_payment' => 0,
+                'bonus_installment' => 0,
+                'direct_required' => 0,
+                'meta' => [
+                    'description' => 'Entry level marketers recruited by MM and above ranks.',
+                    'incentive' => 0,
+                ],
+            ],
+            [
+                'rank' => 'MM',
+                'sequence' => 2,
+                'personal_sales_target' => 100000,
+                'bonus_down_payment' => 5,
+                'bonus_installment' => 2,
+                'direct_required' => 0,
+                'meta' => [
+                    'monthly_incentive' => 20000,
+                ],
+            ],
+            [
+                'rank' => 'DGM',
+                'sequence' => 3,
+                'personal_sales_target' => 100000,
+                'bonus_down_payment' => 10,
+                'bonus_installment' => 4,
+                'direct_required' => 5,
+                'meta' => [
+                    'monthly_incentive' => 50000,
+                ],
+            ],
+            [
+                'rank' => 'GM',
+                'sequence' => 4,
+                'personal_sales_target' => 100000,
+                'bonus_down_payment' => 15,
+                'bonus_installment' => 6,
+                'direct_required' => 10,
+                'meta' => [
+                    'monthly_incentive' => 100000,
+                ],
+            ],
+            [
+                'rank' => 'PD',
+                'sequence' => 5,
+                'personal_sales_target' => 150000,
+                'bonus_down_payment' => 15,
+                'bonus_installment' => 6,
+                'direct_required' => 20,
+                'meta' => [
+                    'monthly_incentive' => 200000,
+                    'fund_percentage' => 3,
+                ],
+            ],
+            [
+                'rank' => 'ED',
+                'sequence' => 6,
+                'personal_sales_target' => 200000,
+                'bonus_down_payment' => 15,
+                'bonus_installment' => 6,
+                'direct_required' => 30,
+                'meta' => [
+                    'quarterly_incentive' => 300000,
+                    'fund_percentage' => 1,
+                ],
+            ],
+            [
+                'rank' => 'DMD',
+                'sequence' => 7,
+                'personal_sales_target' => 250000,
+                'bonus_down_payment' => 15,
+                'bonus_installment' => 6,
+                'direct_required' => 40,
+                'meta' => [
+                    'yearly_incentive' => 500000,
+                    'fund_percentage' => 1,
+                ],
+            ],
+            [
+                'rank' => 'HD',
+                'sequence' => 8,
+                'personal_sales_target' => 300000,
+                'bonus_down_payment' => 20,
+                'bonus_installment' => 8,
+                'direct_required' => 10,
+                'meta' => [
+                    'profit_share' => 20,
+                    'yearly_incentive' => 1000000,
+                ],
+            ],
+        ];
+
+        foreach ($ranks as $rank) {
+            RankRequirement::updateOrCreate(
+                ['rank' => $rank['rank']],
+                Arr::except($rank, ['rank'])
+            );
+        }
+    }
+
+    private function seedLedgerAccounts(): void
+    {
+        $accounts = Config::get('accounting.accounts', []);
+
+        foreach ($accounts as $key => $account) {
+            LedgerAccount::updateOrCreate(
+                ['code' => $account['code']],
+                Arr::only($account, ['name', 'type']) + ['meta' => ['key' => $key]]
+            );
+        }
+    }
+
+    private function seedCommissionRules(): void
+    {
+        $rules = [
+            [
+                'name' => 'Agent Down Payment Commission',
+                'scope' => CommissionRule::SCOPE_GLOBAL,
+                'trigger' => CommissionRule::TRIGGER_ON_PAYMENT,
+                'recipient_type' => \App\Models\Agent::class,
+                'recipient_id' => null,
+                'percentage' => 5,
+                'flat_amount' => null,
+                'active' => true,
+                'meta' => [
+                    'applies_to' => 'down_payment',
+                ],
+            ],
+            [
+                'name' => 'Agent Installment Commission',
+                'scope' => CommissionRule::SCOPE_GLOBAL,
+                'trigger' => CommissionRule::TRIGGER_ON_PAYMENT,
+                'recipient_type' => \App\Models\Agent::class,
+                'recipient_id' => null,
+                'percentage' => 1,
+                'flat_amount' => null,
+                'active' => true,
+                'meta' => [
+                    'applies_to' => 'installment',
+                ],
+            ],
+            [
+                'name' => 'Branch Down Payment Commission',
+                'scope' => CommissionRule::SCOPE_GLOBAL,
+                'trigger' => CommissionRule::TRIGGER_ON_PAYMENT,
+                'recipient_type' => \App\Models\Branch::class,
+                'recipient_id' => null,
+                'percentage' => 5,
+                'flat_amount' => null,
+                'active' => true,
+                'meta' => [
+                    'applies_to' => 'down_payment',
+                ],
+            ],
+            [
+                'name' => 'Branch Installment Commission',
+                'scope' => CommissionRule::SCOPE_GLOBAL,
+                'trigger' => CommissionRule::TRIGGER_ON_PAYMENT,
+                'recipient_type' => \App\Models\Branch::class,
+                'recipient_id' => null,
+                'percentage' => 1,
+                'flat_amount' => null,
+                'active' => true,
+                'meta' => [
+                    'applies_to' => 'installment',
+                ],
+            ],
+            [
+                'name' => 'Director Marketing Down Payment Bonus',
+                'scope' => CommissionRule::SCOPE_GLOBAL,
+                'trigger' => CommissionRule::TRIGGER_ON_PAYMENT,
+                'recipient_type' => \App\Models\User::class,
+                'recipient_id' => null,
+                'percentage' => 5,
+                'flat_amount' => null,
+                'active' => true,
+                'meta' => [
+                    'applies_to' => 'down_payment',
+                    'role' => 'director',
+                ],
+            ],
+            [
+                'name' => 'Owner 01 Down Payment Share',
+                'scope' => CommissionRule::SCOPE_GLOBAL,
+                'trigger' => CommissionRule::TRIGGER_ON_PAYMENT,
+                'recipient_type' => \App\Models\User::class,
+                'recipient_id' => null,
+                'percentage' => 2.5,
+                'flat_amount' => null,
+                'active' => true,
+                'meta' => [
+                    'applies_to' => 'down_payment',
+                    'owner_position' => 'owner_01',
+                ],
+            ],
+            [
+                'name' => 'Owner 02 Down Payment Share',
+                'scope' => CommissionRule::SCOPE_GLOBAL,
+                'trigger' => CommissionRule::TRIGGER_ON_PAYMENT,
+                'recipient_type' => \App\Models\User::class,
+                'recipient_id' => null,
+                'percentage' => 2.5,
+                'flat_amount' => null,
+                'active' => true,
+                'meta' => [
+                    'applies_to' => 'down_payment',
+                    'owner_position' => 'owner_02',
+                ],
+            ],
+        ];
+
+        foreach ($rules as $rule) {
+            CommissionRule::updateOrCreate(
+                ['name' => $rule['name']],
+                Arr::except($rule, ['name'])
+            );
+        }
+    }
+}
+

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        $this->call([
+            RolesSeeder::class,
+            CoreDataSeeder::class,
+            DemoDataSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/DemoDataSeeder.php
+++ b/database/seeders/DemoDataSeeder.php
@@ -1,0 +1,635 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Agent;
+use App\Models\Branch;
+use App\Models\Commission;
+use App\Models\CommissionRule;
+use App\Models\CustomerInstallment;
+use App\Models\Document;
+use App\Models\Employee;
+use App\Models\LedgerAccount;
+use App\Models\LedgerEntry;
+use App\Models\OrderItem;
+use App\Models\Payment;
+use App\Models\PaymentAllocation;
+use App\Models\Product;
+use App\Models\RankMembership;
+use App\Models\RankRequirement;
+use App\Models\SalesOrder;
+use App\Models\Service;
+use App\Models\StockMovement;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class DemoDataSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::transaction(function (): void {
+            $users = $this->seedUsers();
+            $this->seedAgentsAndEmployees($users);
+            $inventory = $this->seedInventory();
+            $this->seedSalesFlow($users, $inventory);
+        });
+    }
+
+    /**
+     * @return array<string, \App\Models\User>
+     */
+    private function seedUsers(): array
+    {
+        $definitions = [
+            'admin@alhamra.test' => [
+                'name' => 'System Admin',
+                'role' => User::ROLE_ADMIN,
+                'spatie_roles' => ['admin'],
+            ],
+            'finance@alhamra.test' => [
+                'name' => 'Finance Manager',
+                'role' => User::ROLE_EMPLOYEE,
+                'spatie_roles' => ['finance'],
+            ],
+            'branch.manager@alhamra.test' => [
+                'name' => 'Branch Manager',
+                'role' => User::ROLE_BRANCH_ADMIN,
+                'spatie_roles' => ['branch-manager'],
+            ],
+            'agent@alhamra.test' => [
+                'name' => 'Lead Agent',
+                'role' => User::ROLE_AGENT_ADMIN,
+                'spatie_roles' => ['agent'],
+            ],
+            'director@alhamra.test' => [
+                'name' => 'Director Marketing',
+                'role' => User::ROLE_DIRECTOR,
+                'spatie_roles' => ['director'],
+            ],
+            'owner.one@alhamra.test' => [
+                'name' => 'Owner 01',
+                'role' => User::ROLE_OWNER,
+                'spatie_roles' => ['owner'],
+            ],
+            'owner.two@alhamra.test' => [
+                'name' => 'Owner 02',
+                'role' => User::ROLE_OWNER,
+                'spatie_roles' => ['owner'],
+            ],
+            'customer@alhamra.test' => [
+                'name' => 'Primary Customer',
+                'role' => 'customer',
+                'spatie_roles' => ['customer'],
+            ],
+            'introducer@alhamra.test' => [
+                'name' => 'Senior Introducer',
+                'role' => User::ROLE_DIRECTOR,
+                'spatie_roles' => ['director'],
+            ],
+        ];
+
+        $users = [];
+
+        foreach ($definitions as $email => $data) {
+            $user = User::updateOrCreate(
+                ['email' => $email],
+                [
+                    'name' => $data['name'],
+                    'password' => Hash::make('password'),
+                    'role' => $data['role'],
+                ]
+            );
+
+            if (! empty($data['spatie_roles'])) {
+                $user->syncRoles($data['spatie_roles']);
+            }
+
+            $users[$email] = $user;
+        }
+
+        return $users;
+    }
+
+    /**
+     * @param array<string, \App\Models\User> $users
+     */
+    private function seedAgentsAndEmployees(array $users): void
+    {
+        $branch = Branch::where('code', 'DHK-HQ')->firstOrFail();
+
+        $agentUser = $users['agent@alhamra.test'];
+        $branchManager = $users['branch.manager@alhamra.test'];
+        $director = $users['director@alhamra.test'];
+
+        $agent = Agent::updateOrCreate(
+            ['user_id' => $agentUser->id],
+            [
+                'branch_id' => $branch->id,
+                'agent_code' => 'AGT-0001',
+            ]
+        );
+
+        Employee::updateOrCreate(
+            ['user_id' => $branchManager->id],
+            [
+                'branch_id' => $branch->id,
+                'rank' => Employee::RANK_MM,
+            ]
+        );
+
+        Employee::updateOrCreate(
+            ['user_id' => $agentUser->id],
+            [
+                'branch_id' => $branch->id,
+                'agent_id' => $agent->id,
+                'rank' => Employee::RANK_ME,
+            ]
+        );
+
+        Employee::updateOrCreate(
+            ['user_id' => $director->id],
+            [
+                'rank' => Employee::RANK_PD,
+            ]
+        );
+
+        $rankRequirement = RankRequirement::where('rank', Employee::RANK_ME)->first();
+
+        RankMembership::updateOrCreate(
+            ['agent_id' => $agent->id, 'rank' => Employee::RANK_ME],
+            [
+                'achieved_at' => Carbon::now()->subMonthsNoOverflow(2),
+                'active' => true,
+                'meta' => [
+                    'requirement_sequence' => $rankRequirement?->sequence,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function seedInventory(): array
+    {
+        $landCategory = CategorySeederHelper::getCategoryId('Land & Plot', 'product');
+        $apartmentCategory = CategorySeederHelper::getCategoryId('Residential Apartment', 'product');
+        $serviceCategory = CategorySeederHelper::getCategoryId('Hajj & Umrah Package', 'service');
+
+        $landProduct = Product::updateOrCreate(
+            ['name' => 'Bashundhara Residential Plot'],
+            [
+                'category_id' => $landCategory,
+                'product_type' => 'land',
+                'price' => 5000000,
+                'attributes' => [
+                    'size' => '5 katha',
+                    'location' => 'Bashundhara Block D',
+                ],
+                'stock_qty' => 10,
+                'min_stock_alert' => 1,
+                'is_stock_managed' => true,
+            ]
+        );
+
+        $apartmentProduct = Product::updateOrCreate(
+            ['name' => 'Premium Apartment Unit'],
+            [
+                'category_id' => $apartmentCategory,
+                'product_type' => 'big',
+                'price' => 8000000,
+                'attributes' => [
+                    'bedrooms' => 4,
+                    'bathrooms' => 3,
+                ],
+                'stock_qty' => 5,
+                'min_stock_alert' => 1,
+                'is_stock_managed' => true,
+            ]
+        );
+
+        $hajjService = Service::updateOrCreate(
+            ['name' => 'Premium Hajj Package'],
+            [
+                'category_id' => $serviceCategory,
+                'price' => 800000,
+                'attributes' => [
+                    'duration' => '30 days',
+                    'includes' => ['visa', 'hotel', 'transport'],
+                ],
+            ]
+        );
+
+        StockMovement::updateOrCreate(
+            ['product_id' => $landProduct->id, 'ref_type' => 'seed-initial', 'ref_id' => $landProduct->id],
+            [
+                'type' => StockMovement::TYPE_IN,
+                'qty' => 10,
+                'note' => 'Initial stock for demo seeding',
+            ]
+        );
+
+        StockMovement::updateOrCreate(
+            ['product_id' => $apartmentProduct->id, 'ref_type' => 'seed-initial', 'ref_id' => $apartmentProduct->id],
+            [
+                'type' => StockMovement::TYPE_IN,
+                'qty' => 5,
+                'note' => 'Initial stock for demo seeding',
+            ]
+        );
+
+        return [
+            'land' => $landProduct,
+            'apartment' => $apartmentProduct,
+            'service' => $hajjService,
+        ];
+    }
+
+    /**
+     * @param array<string, \App\Models\User> $users
+     * @param array<string, mixed> $inventory
+     */
+    private function seedSalesFlow(array $users, array $inventory): void
+    {
+        $branch = Branch::where('code', 'DHK-HQ')->firstOrFail();
+        $agent = Agent::where('agent_code', 'AGT-0001')->firstOrFail();
+        $agentEmployee = Employee::where('agent_id', $agent->id)->first();
+
+        $customer = $users['customer@alhamra.test'];
+        $introducer = $users['introducer@alhamra.test'];
+        $director = $users['director@alhamra.test'];
+        $ownerOne = $users['owner.one@alhamra.test'];
+        $ownerTwo = $users['owner.two@alhamra.test'];
+
+        $downPayment = 500000;
+
+        $salesOrder = SalesOrder::updateOrCreate(
+            [
+                'customer_id' => $customer->id,
+                'branch_id' => $branch->id,
+                'agent_id' => $agent->id,
+                'sales_type' => SalesOrder::TYPE_ORDER,
+            ],
+            [
+                'employee_id' => $agentEmployee?->id,
+                'rank' => Employee::RANK_ME,
+                'introducer_id' => $introducer->id,
+                'down_payment' => $downPayment,
+                'total' => 5800000,
+                'status' => SalesOrder::STATUS_ACTIVE,
+            ]
+        );
+
+        $items = [
+            [
+                'model' => $inventory['land'],
+                'qty' => 1,
+                'unit_price' => 5000000,
+            ],
+            [
+                'model' => $inventory['service'],
+                'qty' => 1,
+                'unit_price' => 800000,
+            ],
+        ];
+
+        foreach ($items as $item) {
+            OrderItem::updateOrCreate(
+                [
+                    'sales_order_id' => $salesOrder->id,
+                    'itemable_id' => $item['model']->id,
+                    'itemable_type' => $item['model']::class,
+                ],
+                [
+                    'qty' => $item['qty'],
+                    'unit_price' => $item['unit_price'],
+                    'line_total' => $item['qty'] * $item['unit_price'],
+                ]
+            );
+        }
+
+        StockMovement::updateOrCreate(
+            [
+                'product_id' => $inventory['land']->id,
+                'ref_type' => 'sales-order',
+                'ref_id' => $salesOrder->id,
+            ],
+            [
+                'type' => StockMovement::TYPE_OUT,
+                'qty' => 1,
+                'note' => 'Reserved for customer order',
+            ]
+        );
+
+        $installments = [
+            [
+                'due_date' => Carbon::now()->addMonth(),
+                'amount' => 2000000,
+                'paid' => 2000000,
+                'status' => 'paid',
+            ],
+            [
+                'due_date' => Carbon::now()->addMonthsNoOverflow(2),
+                'amount' => 2000000,
+                'paid' => 0,
+                'status' => 'due',
+            ],
+            [
+                'due_date' => Carbon::now()->addMonthsNoOverflow(3),
+                'amount' => 1300000,
+                'paid' => 0,
+                'status' => 'due',
+            ],
+        ];
+
+        $installmentModels = [];
+
+        foreach ($installments as $index => $installment) {
+            $model = CustomerInstallment::updateOrCreate(
+                [
+                    'sales_order_id' => $salesOrder->id,
+                    'due_date' => $installment['due_date'],
+                ],
+                Arr::only($installment, ['amount', 'paid', 'status'])
+            );
+
+            $installmentModels[$index] = $model;
+        }
+
+        $downPaymentRecord = Payment::updateOrCreate(
+            [
+                'sales_order_id' => $salesOrder->id,
+                'type' => 'down_payment',
+            ],
+            [
+                'paid_at' => Carbon::now()->subDays(5),
+                'amount' => $downPayment,
+                'method' => 'bank',
+            ]
+        );
+
+        $installmentPayment = Payment::updateOrCreate(
+            [
+                'sales_order_id' => $salesOrder->id,
+                'type' => 'installment',
+                'paid_at' => $installments[0]['due_date'],
+            ],
+            [
+                'amount' => 2000000,
+                'method' => 'bank',
+            ]
+        );
+
+        PaymentAllocation::updateOrCreate(
+            [
+                'payment_id' => $installmentPayment->id,
+                'customer_installment_id' => $installmentModels[0]->id,
+            ],
+            [
+                'allocated' => 2000000,
+            ]
+        );
+
+        $this->seedCommissions(
+            $downPaymentRecord,
+            $installmentPayment,
+            $agent,
+            $branch,
+            $director,
+            $ownerOne,
+            $ownerTwo
+        );
+
+        $this->seedLedgerEntries($salesOrder, $downPaymentRecord, $installmentPayment);
+
+        Document::updateOrCreate(
+            [
+                'documentable_type' => SalesOrder::class,
+                'documentable_id' => $salesOrder->id,
+                'path' => 'contracts/so-2025-0001.pdf',
+            ],
+            [
+                'category' => 'contract',
+                'disk' => 'local',
+                'original_name' => 'SO-2025-0001.pdf',
+                'mime_type' => 'application/pdf',
+                'size' => 245760,
+                'uploaded_by' => $users['admin@alhamra.test']->id,
+            ]
+        );
+    }
+
+    private function seedCommissions(
+        Payment $downPayment,
+        Payment $installmentPayment,
+        Agent $agent,
+        Branch $branch,
+        User $director,
+        User $ownerOne,
+        User $ownerTwo
+    ): void {
+        $rules = CommissionRule::whereIn('name', [
+            'Agent Down Payment Commission',
+            'Agent Installment Commission',
+            'Branch Down Payment Commission',
+            'Branch Installment Commission',
+            'Director Marketing Down Payment Bonus',
+            'Owner 01 Down Payment Share',
+            'Owner 02 Down Payment Share',
+        ])->get()->keyBy('name');
+
+        if (($rules['Director Marketing Down Payment Bonus'] ?? null) && ! $rules['Director Marketing Down Payment Bonus']->recipient_id) {
+            $rules['Director Marketing Down Payment Bonus']->update(['recipient_id' => $director->id]);
+        }
+
+        if (($rules['Owner 01 Down Payment Share'] ?? null) && ! $rules['Owner 01 Down Payment Share']->recipient_id) {
+            $rules['Owner 01 Down Payment Share']->update(['recipient_id' => $ownerOne->id]);
+        }
+
+        if (($rules['Owner 02 Down Payment Share'] ?? null) && ! $rules['Owner 02 Down Payment Share']->recipient_id) {
+            $rules['Owner 02 Down Payment Share']->update(['recipient_id' => $ownerTwo->id]);
+        }
+
+        $downPaymentAmount = $downPayment->amount;
+        $installmentAmount = $installmentPayment->amount;
+
+        $commissionDefinitions = [
+            [
+                'rule' => $rules['Agent Down Payment Commission'] ?? null,
+                'payment' => $downPayment,
+                'recipient_type' => Agent::class,
+                'recipient_id' => $agent->id,
+                'amount' => $downPaymentAmount * 0.05,
+            ],
+            [
+                'rule' => $rules['Agent Installment Commission'] ?? null,
+                'payment' => $installmentPayment,
+                'recipient_type' => Agent::class,
+                'recipient_id' => $agent->id,
+                'amount' => $installmentAmount * 0.01,
+            ],
+            [
+                'rule' => $rules['Branch Down Payment Commission'] ?? null,
+                'payment' => $downPayment,
+                'recipient_type' => Branch::class,
+                'recipient_id' => $branch->id,
+                'amount' => $downPaymentAmount * 0.05,
+            ],
+            [
+                'rule' => $rules['Branch Installment Commission'] ?? null,
+                'payment' => $installmentPayment,
+                'recipient_type' => Branch::class,
+                'recipient_id' => $branch->id,
+                'amount' => $installmentAmount * 0.01,
+            ],
+            [
+                'rule' => $rules['Director Marketing Down Payment Bonus'] ?? null,
+                'payment' => $downPayment,
+                'recipient_type' => User::class,
+                'recipient_id' => $director->id,
+                'amount' => $downPaymentAmount * 0.05,
+            ],
+            [
+                'rule' => $rules['Owner 01 Down Payment Share'] ?? null,
+                'payment' => $downPayment,
+                'recipient_type' => User::class,
+                'recipient_id' => $ownerOne->id,
+                'amount' => $downPaymentAmount * 0.025,
+            ],
+            [
+                'rule' => $rules['Owner 02 Down Payment Share'] ?? null,
+                'payment' => $downPayment,
+                'recipient_type' => User::class,
+                'recipient_id' => $ownerTwo->id,
+                'amount' => $downPaymentAmount * 0.025,
+            ],
+        ];
+
+        foreach ($commissionDefinitions as $definition) {
+            if (! $definition['rule']) {
+                continue;
+            }
+
+            Commission::updateOrCreate(
+                [
+                    'commission_rule_id' => $definition['rule']->id,
+                    'payment_id' => $definition['payment']->id,
+                    'recipient_type' => $definition['recipient_type'],
+                    'recipient_id' => $definition['recipient_id'],
+                ],
+                [
+                    'sales_order_id' => $definition['payment']->sales_order_id,
+                    'amount' => round($definition['amount'], 2),
+                    'status' => 'unpaid',
+                ]
+            );
+        }
+    }
+
+    private function seedLedgerEntries(SalesOrder $order, Payment $downPayment, Payment $installmentPayment): void
+    {
+        $accounts = LedgerAccount::whereIn('code', ['101', '110', '510', '210'])->get()->keyBy('code');
+        $txDownPayment = 'SO-'.$order->id.'-DP';
+        $txInstallment = 'SO-'.$order->id.'-INS1';
+        $txCommission = 'SO-'.$order->id.'-COM-DP';
+
+        $this->createLedgerPair(
+            $txDownPayment,
+            $accounts['101'] ?? null,
+            $accounts['110'] ?? null,
+            $downPayment->amount,
+            Carbon::now()->subDays(5)
+        );
+
+        $this->createLedgerPair(
+            $txInstallment,
+            $accounts['101'] ?? null,
+            $accounts['110'] ?? null,
+            $installmentPayment->amount,
+            $installmentPayment->paid_at ?? Carbon::now()
+        );
+
+        $commissionTotal = Commission::where('payment_id', $downPayment->id)->sum('amount');
+
+        if ($commissionTotal > 0) {
+            $this->createLedgerPair(
+                $txCommission,
+                $accounts['510'] ?? null,
+                $accounts['210'] ?? null,
+                $commissionTotal,
+                Carbon::now()->subDays(4)
+            );
+        }
+    }
+
+    private function createLedgerPair(
+        string $txId,
+        ?LedgerAccount $debitAccount,
+        ?LedgerAccount $creditAccount,
+        float $amount,
+        Carbon $occurredAt
+    ): void {
+        if (! $debitAccount || ! $creditAccount) {
+            return;
+        }
+
+        LedgerEntry::updateOrCreate(
+            [
+                'tx_id' => $txId,
+                'account_id' => $debitAccount->id,
+            ],
+            [
+                'debit' => $amount,
+                'credit' => 0,
+                'occurred_at' => $occurredAt,
+            ]
+        );
+
+        LedgerEntry::updateOrCreate(
+            [
+                'tx_id' => $txId,
+                'account_id' => $creditAccount->id,
+            ],
+            [
+                'debit' => 0,
+                'credit' => $amount,
+                'occurred_at' => $occurredAt,
+            ]
+        );
+    }
+}
+
+/**
+ * Helper for retrieving category identifiers while keeping DemoDataSeeder concise.
+ */
+final class CategorySeederHelper
+{
+    public static function getCategoryId(string $name, ?string $type = null): int
+    {
+        $query = \App\Models\Category::query()->where('name', $name);
+
+        if ($type) {
+            $query->where('type', $type);
+        }
+
+        $categoryId = $query->value('id');
+
+        if ($categoryId) {
+            return $categoryId;
+        }
+
+        $fallbackQuery = \App\Models\Category::query();
+
+        if ($type) {
+            $fallbackQuery->where('type', $type);
+        }
+
+        return $fallbackQuery->value('id')
+            ?? throw new \RuntimeException('Category not found for '.$name);
+    }
+}
+

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -2,8 +2,9 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 class RolesSeeder extends Seeder
 {
@@ -12,6 +13,44 @@ class RolesSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        $permissions = [
+            'manage users',
+            'manage branches',
+            'manage agents',
+            'manage products',
+            'manage services',
+            'manage sales orders',
+            'manage payments',
+            'manage commissions',
+            'manage ranks',
+            'manage accounting',
+            'view reports',
+        ];
+
+        $permissionModels = collect($permissions)->mapWithKeys(function (string $name) {
+            $permission = Permission::firstOrCreate(
+                ['name' => $name, 'guard_name' => 'web']
+            );
+
+            return [$name => $permission];
+        });
+
+        $roles = [
+            'admin' => $permissions,
+            'finance' => ['manage payments', 'manage commissions', 'manage accounting', 'view reports'],
+            'branch-manager' => ['manage agents', 'manage sales orders', 'manage payments', 'view reports'],
+            'agent' => ['manage sales orders', 'view reports'],
+            'director' => ['manage ranks', 'manage commissions', 'view reports'],
+            'owner' => ['view reports'],
+            'customer' => [],
+        ];
+
+        foreach ($roles as $roleName => $rolePermissions) {
+            $role = Role::firstOrCreate(
+                ['name' => $roleName, 'guard_name' => 'web']
+            );
+
+            $role->syncPermissions($permissionModels->only($rolePermissions)->values());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Spatie role support to the User model and wire up role seeding
- seed reference data such as branches, categories, rank requirements, ledger accounts, and commission rules
- populate rich demo data for users, inventory, sales, payments, commissions, documents, and ledger activity

## Testing
- php artisan db:seed *(fails locally because the vendor directory is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e4e75505e08333b558868060856f7f